### PR TITLE
MAB-803 - Changes to use latest provder for testing. Updated warnings and diag settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,20 +44,36 @@ resource "azurerm_monitor_diagnostic_setting" "update_management" {
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.log_analytics_workspace.id
 
   log {
-    category = "JobLogs"
+    category  = "JobLogs"
+    enabled   = true
   }
   log {
-    category = "JobStreams"
+    category  = "JobStreams"
+    enabled   = true
   }
   log {
-    category = "DscNodeStatus"
+    category  = "DscNodeStatus"
+    enabled   = true
   }
+  log {
+    category  = "AuditEvent"
+    enabled   = false
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
 
 }
 
 data "azurerm_subscription" "current" {}
 
-resource "azurerm_dashboard" "patching_dashboard" {
+resource "azurerm_portal_dashboard" "patching_dashboard" {
   name                  = "patching${random_string.random_string.result}"
   resource_group_name   = data.azurerm_log_analytics_workspace.log_analytics_workspace.resource_group_name
   location              = var.location != null ? var.location : data.azurerm_log_analytics_workspace.log_analytics_workspace.location

--- a/tests/basic/provider.tf
+++ b/tests/basic/provider.tf
@@ -12,7 +12,6 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.97.0"
     }
   }
 }


### PR DESCRIPTION
Tests set to always use the latest provider to ensure any wanrings or fixes are picked up. Also adjusted some warnings for new provider and updated diagnostics settingds to set all required items whether false or not.